### PR TITLE
Just import Exporter's "import" instead of inheriting from it

### DIFF
--- a/META.json
+++ b/META.json
@@ -43,8 +43,8 @@
       },
       "runtime" : {
          "requires" : {
+            "Exporter" : "5.57",
             "TOML::Parser" : "0.04",
-            "parent" : "0",
             "perl" : "5.008005"
          }
       },

--- a/cpanfile
+++ b/cpanfile
@@ -1,5 +1,5 @@
 requires 'TOML::Parser', '0.04';
-requires 'parent';
+requires 'Exporter', '5.57';
 
 on configure => sub {
     requires 'Module::Build::Tiny', '0.035';

--- a/lib/TOML.pm
+++ b/lib/TOML.pm
@@ -9,7 +9,7 @@ package TOML;
 use 5.008005;
 use strict;
 use warnings;
-use parent qw(Exporter);
+use Exporter 'import';
 
 our ($VERSION, @EXPORT, @_NAMESPACE, $PARSER);
 


### PR DESCRIPTION
`use parent 'Exporter';` => `use Exporter 5.57 'import';`
Do not inherit anymore from Exporter. Inheriting pollutes the namespace.
This feature requires Exporter 5.57 that appeared in core with perl 5.8.3. This does not change anything because TOML already requires perl 5.8.5.

By the way, this also removes a dependency on parent.pm.