### PR TITLE
Don't escape forward slash.

### DIFF
--- a/lib/TOML.pm
+++ b/lib/TOML.pm
@@ -91,7 +91,6 @@ sub string_to_json {
     my ($arg) = @_;
 
     $arg =~ s/([\x22\x5c\n\r\t\f\b])/$esc{$1}/g;
-    $arg =~ s/\//\\\//g if 1;
     $arg =~ s/([\x00-\x08\x0b\x0e-\x1f])/'\\u00' . unpack('H2', $1)/eg;
 
     return '"' . $arg . '"';

--- a/t/to_toml.t
+++ b/t/to_toml.t
@@ -65,6 +65,14 @@ is(to_toml(+{ bar => \0 }), <<'...');
 bar = false
 ...
 
+test(
+    +{
+        path => 'foo/bar',
+    }
+, <<'...', 'filesystem path');
+path = "foo/bar"
+...
+
 done_testing;
 
 sub test {


### PR DESCRIPTION
Version 0.4 of toml specification removed forward slash from list of allowed escapes.
